### PR TITLE
decouple open value from <DynamicPopover/>

### DIFF
--- a/components/src/components/molecules/Tooltip/Tooltip.test.tsx
+++ b/components/src/components/molecules/Tooltip/Tooltip.test.tsx
@@ -10,14 +10,26 @@ import { Tooltip } from './Tooltip'
 
 import { lightTheme } from '@/src/tokens'
 
-const TooltipHelper = ({ ...props }: any) => {
+const TooltipHelper = () => {
+  const [isOpen, setIsOpen] = React.useState(false)
   const content = <div data-testid="tooltipcontent">Content</div>
   return (
     <ThemeProvider theme={lightTheme}>
-      <div>
+      <div style={{ width: '500px', height: '500px' }}>
         <div>outside</div>
-        <Tooltip content={content} {...props}>
-          <Button>Click me</Button>
+        <Tooltip
+          content={content}
+          open={isOpen}
+          placement="right-start"
+          onDismiss={() => setIsOpen(false)}
+        >
+          <Button
+            onClick={() => {
+              setIsOpen((o) => !o)
+            }}
+          >
+            Click me
+          </Button>
         </Tooltip>
       </div>
     </ThemeProvider>
@@ -26,26 +38,34 @@ const TooltipHelper = ({ ...props }: any) => {
 
 describe('<Tooltip />', () => {
   afterEach(cleanup)
+  jest.setTimeout(10000)
 
   it('renders', () => {
     render(<TooltipHelper />)
     expect(screen.getByTestId('dynamicpopover')).toBeInTheDocument()
     expect(screen.getByText('Click me')).toBeInTheDocument()
     expect(screen.getByTestId('tooltipcontent')).toBeInTheDocument()
+    expect(screen.getByText('outside')).toBeInTheDocument()
+    expect(screen.getByTestId('dynamicpopover-popover')).toBeInTheDocument()
   })
 
-  it('should show popover when clicked', () => {
+  it('should show popover when clicked', async () => {
     render(<TooltipHelper />)
     act(() => {
       userEvent.click(screen.getByText('Click me'))
     })
-    expect(screen.getByText('Click me')).toBeVisible()
+    await waitFor(() => {
+      expect(screen.getByTestId('tooltipcontent')).toBeVisible()
+    })
   })
 
   it('should close if clicking outside of dropdown', async () => {
     render(<TooltipHelper />)
     act(() => {
       userEvent.click(screen.getByText('Click me'))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('tooltipcontent')).toBeVisible()
     })
     act(() => {
       userEvent.click(screen.getByText('outside'))

--- a/docs/src/components/CodePreview/CodePreview.tsx
+++ b/docs/src/components/CodePreview/CodePreview.tsx
@@ -104,6 +104,7 @@ export const CodePreview = ({
         NextLink,
         avatars,
         Stack,
+        css,
         keyframes,
       }}
       theme={theme}

--- a/docs/src/playroom/components.ts
+++ b/docs/src/playroom/components.ts
@@ -1,4 +1,4 @@
 export * from '@ensdomains/thorin'
 export { Stack } from '../components/Stack'
 export { default as ComponentWrapper } from './ComponentWrapper'
-export { keyframes } from 'styled-components'
+export { css } from 'styled-components'

--- a/docs/src/reference/mdx/atoms/DynamicPopover.docs.mdx
+++ b/docs/src/reference/mdx/atoms/DynamicPopover.docs.mdx
@@ -34,7 +34,7 @@ A function that provides custom animations to the popover appearing and disappea
 type DynamicPopoverAnimationFunc = (
   side: DynamicPopoverSide,
   open?: boolean,
-) => Keyframes
+) => string
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ type DynamicPopoverAnimationFunc = (
       required: true,
     },
     open: {
-      name: 'onClick',
+      name: 'open',
       description: 'If true, the popover is visible',
       type: {
         raw: 'boolean',
@@ -61,36 +61,22 @@ type DynamicPopoverAnimationFunc = (
 
 ### Return
 
-Returns a Keyframes object created from `keyframes` module of the `styled-components` library.
+Returns a string of css attributes.
 
 ```tsx live=true expand=ture minHeight=300px
 <DynamicPopover
   animationFn={(side, open) => {
     if (open)
-      return keyframes`
-    0% {
+      return `
+        transform: scale(1);
+        visibility: visible;
+        opacity: 1;
+      `
+    return `
       transform: scale(0.2);
       visibility: hidden;
       opacity: 0;
-    }
-    100% {
-      transform: scale(1);
-      visibility: visible;
-      opacity: 1;
-    }
-  `
-    return keyframes`
-  0% {
-    transform: scale(1);
-    visibility: visible;
-    opacity: 1;  
-  }
-  100% {
-    transform: scale(0.2);
-    visibility: hidden;
-    opacity: 0;  
-  }
-  `
+    `
   }}
   open={getState('isOpen')}
   placement="bottom-start"
@@ -111,29 +97,15 @@ Prevents the popover from appearing
 <DynamicPopover
   animationFn={(side, open) => {
     if (open)
-      return keyframes`
-    0% {
-      transform: scale(0.2);
-      visibility: hidden;
-      opacity: 0;
-    }
-    100% {
+      return `
       transform: scale(1);
       visibility: visible;
       opacity: 1;
-    }
   `
-    return keyframes`
-  0% {
-    transform: scale(1);
-    visibility: visible;
-    opacity: 1;  
-  }
-  100% {
+    return `
     transform: scale(0.2);
     visibility: hidden;
     opacity: 0;  
-  }
   `
   }}
   disabled={getState('isDisabled')}

--- a/docs/src/reference/mdx/molecules/Tooltip.docs.mdx
+++ b/docs/src/reference/mdx/molecules/Tooltip.docs.mdx
@@ -8,8 +8,15 @@ import { Tooltip, TooltipProps } from '@ensdomains/thorin'
 ```
 
 ```tsx live=true  expand=ture minHeight=300px
-<Tooltip content={<div>Content</div>} placement="bottom-start">
-  <Button>Click me</Button>
+<Tooltip
+  content={<div>Content</div>}
+  open={getState('isOpen')}
+  placement="bottom-start"
+  onDismiss={() => setState('isOpen', false)}
+>
+  <Button pressed={getState('isOpen')} onClick={() => toggleState('isOpen')}>
+    Click me
+  </Button>
 </Tooltip>
 ```
 
@@ -19,37 +26,151 @@ import { Tooltip, TooltipProps } from '@ensdomains/thorin'
 
 ## Placement
 
-```tsx live=true  expand=ture minHeight=300px
-<Stack>
-  <Stack flexDirection="row" justifyContent="space-between">
-    <Tooltip content={<div>Content</div>} placement="bottom-start">
-      <Button>Click me</Button>
-    </Tooltip>
-    <Tooltip content={<div>Content</div>} placement="bottom-center">
-      <Button>Click me</Button>
-    </Tooltip>
-    <Tooltip content={<div>Content</div>} placement="bottom-end">
-      <Button>Click me</Button>
-    </Tooltip>
-  </Stack>
-  <Stack flexDirection="row" justifyContent="space-between">
-    <Tooltip content={<div>Content</div>} placement="right-center">
-      <Button>Click me</Button>
-    </Tooltip>
-    <Tooltip content={<div>Content</div>} placement="left-center">
-      <Button>Click me</Button>
-    </Tooltip>
-  </Stack>
-  <Stack flexDirection="row" justifyContent="space-between">
-    <Tooltip content={<div>Content</div>} placement="top-start">
-      <Button>Click me</Button>
-    </Tooltip>
-    <Tooltip content={<div>Content</div>} placement="top-center">
-      <Button>Click me</Button>
-    </Tooltip>
-    <Tooltip content={<div>Content</div>} placement="top-end">
-      <Button>Click me</Button>
-    </Tooltip>
-  </Stack>
+### Bottom
+
+```tsx live=true  expand=ture minHeight=200px
+<Stack flexDirection="row" justifyContent="space-between">
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen1')}
+    placement="bottom-start"
+    onDismiss={() => setState('isOpen1', false)}
+  >
+    <Button
+      pressed={getState('isOpen1')}
+      onClick={() => toggleState('isOpen1')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen2')}
+    placement="bottom-center"
+    onDismiss={() => setState('isOpen2', false)}
+  >
+    <Button
+      pressed={getState('isOpen2')}
+      onClick={() => toggleState('isOpen2')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen3')}
+    placement="bottom-end"
+    onDismiss={() => setState('isOpen3', false)}
+  >
+    <Button
+      pressed={getState('isOpen3')}
+      onClick={() => toggleState('isOpen3')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
 </Stack>
+```
+
+### Horizontal
+
+```tsx live=true  expand=ture minHeight=200px
+<Stack alignItems="center" flexDirection="column">
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen1')}
+    placement={`${getState('side')}-start`}
+    onDismiss={() => setState('isOpen1', false)}
+  >
+    <Button
+      pressed={getState('isOpen1')}
+      onClick={() => toggleState('isOpen1')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen2')}
+    placement={`${getState('side')}-center`}
+    onDismiss={() => setState('isOpen2', false)}
+  >
+    <Button
+      pressed={getState('isOpen2')}
+      onClick={() => toggleState('isOpen2')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
+  <Tooltip
+    content={<div>Content</div>}
+    open={getState('isOpen3')}
+    placement={`${getState('side')}-end`}
+    onDismiss={() => setState('isOpen3', false)}
+  >
+    <Button
+      pressed={getState('isOpen3')}
+      onClick={() => toggleState('isOpen3')}
+    >
+      Click me
+    </Button>
+  </Tooltip>
+  <Button
+    onClick={() =>
+      setState('side', getState('side') === 'right' ? 'left' : 'right')
+    }
+  >
+    Switch Side
+  </Button>
+  <VisuallyHidden>{setDefaultState('side', 'left')}</VisuallyHidden>
+</Stack>
+```
+
+### Top
+
+```tsx live=true  expand=ture minHeight=200px
+<>
+  <div style={{ marginTop: '100px' }} />
+  <Stack flexDirection="row" justifyContent="space-between">
+    <Tooltip
+      content={<div>Content</div>}
+      open={getState('isOpen1')}
+      placement="top-start"
+      onDismiss={() => setState('isOpen1', false)}
+    >
+      <Button
+        pressed={getState('isOpen1')}
+        onClick={() => toggleState('isOpen1')}
+      >
+        Click me
+      </Button>
+    </Tooltip>
+    <Tooltip
+      content={<div>Content</div>}
+      open={getState('isOpen2')}
+      placement="top-center"
+      onDismiss={() => setState('isOpen2', false)}
+    >
+      <Button
+        pressed={getState('isOpen2')}
+        onClick={() => toggleState('isOpen2')}
+      >
+        Click me
+      </Button>
+    </Tooltip>
+    <Tooltip
+      content={<div>Content</div>}
+      open={getState('isOpen3')}
+      placement="top-end"
+      onDismiss={() => setState('isOpen3', false)}
+    >
+      <Button
+        pressed={getState('isOpen3')}
+        onClick={() => toggleState('isOpen3')}
+      >
+        Click me
+      </Button>
+    </Tooltip>
+  </Stack>
+</>
 ```


### PR DESCRIPTION
In instance where the popovers are mixed with other elements dependent on mobile vs desktop, it becomes impossible to synchronize state with the open logic embedded inside the DynamicPopover component.

NOTES
* Removed the use of keyframes for animation since they are not testable in Jest
* Removed usage of lodash component
* Turned off live editing in the docs for the animationFn sample code because the way that LivePreview works with setState it reloads the entire component on every change and the custom animation doesn't work since on first render the value is undefined.