### PR TITLE
Add value property to dropdown items

### DIFF
--- a/components/src/components/molecules/Dropdown/Dropdown.tsx
+++ b/components/src/components/molecules/Dropdown/Dropdown.tsx
@@ -20,7 +20,8 @@ const Container = styled.div(
 
 type DropdownItemObject = {
   label: string
-  onClick(): void
+  onClick(value?: string): void
+  value?: string
   color?: Colors
   disabled?: boolean
 }
@@ -267,12 +268,16 @@ const DropdownMenu = ({
         if (React.isValidElement(item)) {
           return <div onClick={() => setIsOpen(false)}>{item}</div>
         }
-        const { color, label, onClick, disabled } = item as DropdownItemObject
+        const { color, value, label, onClick, disabled } =
+          item as DropdownItemObject
+
         return (
           <MenuButton
             {...{ $inner: inner, $hasColor: !!color, $color: color, disabled }}
-            key={label}
-            onClick={() => Promise.resolve(setIsOpen(false)).then(onClick)}
+            key={value || label}
+            onClick={() =>
+              Promise.resolve(setIsOpen(false)).then(() => onClick(value))
+            }
           >
             {label}
           </MenuButton>


### PR DESCRIPTION
Label values are not a consistent way to define keys when using translation. Adds an optional value property to drop down items that can be used as the key. 