### PR TITLE
update flex responsiveness for <Field /> labels

### DIFF
--- a/components/src/components/atoms/Field/Field.tsx
+++ b/components/src/components/atoms/Field/Field.tsx
@@ -45,11 +45,18 @@ type Props = FieldBaseProps & {
   disabled?: boolean
 } & Omit<NativeLabelProps, 'id' | 'children'>
 
-const Label = styled(Typography)<{ $disabled?: boolean; $readOnly?: boolean }>(
-  ({ $disabled, $readOnly }) => css`
+const Label = styled.label<{
+  $disabled?: boolean
+  $readOnly?: boolean
+  $required?: boolean
+}>(
+  ({ theme, $disabled, $readOnly, $required }) => css`
     display: flex;
-    flex: 66%;
+    flex-basis: auto;
+    flex-grow: 2;
+    flex-shrink: 1;
     overflow: hidden;
+    position: relative;
     cursor: pointer;
 
     ${$readOnly &&
@@ -62,12 +69,28 @@ const Label = styled(Typography)<{ $disabled?: boolean; $readOnly?: boolean }>(
     css`
       cursor: not-allowed;
     `}
+
+    ${$required &&
+    css`
+      ::after {
+        content: ' *';
+        white-space: pre;
+        color: ${theme.colors.red};
+      }
+    `}
   `,
 )
 
+const InnerLabel = styled(Typography)(() => css``)
+
 const SecondaryLabel = styled(Typography)(
   () => css`
-    flex: 33%;
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 2;
+    text-align: right;
+    overflow: hidden;
+    position: relative;
   `,
 )
 
@@ -77,16 +100,7 @@ const LabelContentContainer = styled.div<{ $inline?: boolean }>(
     align-items: center;
     padding: 0 ${$inline ? '0' : theme.space['2']};
     overflow: hidden;
-  `,
-)
-
-const RequiredWrapper = styled.span(
-  ({ theme }) => css`
-    color: ${theme.colors.red};
-    ::before {
-      content: ' ';
-      white-space: pre;
-    }
+    gap: ${theme.space['2']};
   `,
 )
 
@@ -114,19 +128,13 @@ const LabelContent = ({
       <Label
         $disabled={disabled}
         $readOnly={readOnly}
-        asProp="label"
-        color="greyPrimary"
-        ellipsis
-        fontVariant="bodyBold"
+        $required={required}
         {...ids.label}
       >
-        {label}
-        {required && (
-          <>
-            <RequiredWrapper>*</RequiredWrapper>
-            <VisuallyHidden>required</VisuallyHidden>
-          </>
-        )}
+        <InnerLabel color="greyPrimary" ellipsis fontVariant="bodyBold">
+          {label}
+          {required && <VisuallyHidden>required</VisuallyHidden>}
+        </InnerLabel>
       </Label>
       {labelSecondary && (
         <SecondaryLabel color="greyPrimary" ellipsis fontVariant="extraSmall">

--- a/docs/src/reference/mdx/atoms/Field.docs.mdx
+++ b/docs/src/reference/mdx/atoms/Field.docs.mdx
@@ -9,18 +9,14 @@ import { Field } from '@ensdomains/thorin'
 
 ```tsx live=true expand=true
 <DeleteMe>
-  <Field
-    description="Descriptionasdfasdfasdfasdfasdfasd"
-    label="Labelasdfasdfasdfasdfasdf"
-    labelSecondary="Secondaryasdfasdfasdfas"
-  >
+  <Field description="Description" label="Label" labelSecondary="Secondary">
     <div style={{ backgroundColor: 'black', height: 20 }} />
   </Field>
   <Field
-    description="Descriptionasdfasdfasdfasdfasdf"
+    description="Description"
     inline
-    label="Labelasdfasdfasdfasdfasdfasd"
-    labelSecondary="Secondaryasdfasdfasdfasdfasfdasd"
+    label="Label"
+    labelSecondary="Secondary"
   >
     <div style={{ backgroundColor: 'black', width: 20, height: 20 }} />
   </Field>


### PR DESCRIPTION
Adjust the flex setting on the label components for <Field />.
1. Make the secondary label not grow and have low priority in sharing space if primary label overflows.

Turned the required * into ::after content so that if the label overflows it will still be visible.

Wrapped the label content in label instead of using as="label" from Typography since it is inconsistent in applying styles.