### PR TITLE
fix: layout of dialog buttons

### DIFF
--- a/components/src/components/organisms/Dialog/Dialog.tsx
+++ b/components/src/components/organisms/Dialog/Dialog.tsx
@@ -129,7 +129,6 @@ const ButtonsContainer = styled.div(
     flex-direction: column;
     gap: ${theme.space['2']};
     width: ${theme.space.full};
-    max-width: ${theme.space['96']};
     ${mq.sm.min(css`
       flex-direction: row;
     `)}

--- a/components/src/components/organisms/Dialog/Dialog.tsx
+++ b/components/src/components/organisms/Dialog/Dialog.tsx
@@ -121,15 +121,18 @@ const SubTitle = styled(Typography)(
   `,
 )
 
-const ButtonsContainer = styled.div<{ $center?: boolean }>(
-  ({ theme, $center }) => css`
+const ButtonsContainer = styled.div(
+  ({ theme }) => css`
     display: flex;
     align-items: center;
     justify-content: stretch;
-    flex-direction: ${$center ? 'column' : 'row'};
+    flex-direction: column;
     gap: ${theme.space['2']};
     width: ${theme.space.full};
     max-width: ${theme.space['96']};
+    ${mq.sm.min(css`
+      flex-direction: row;
+    `)}
   `,
 )
 
@@ -262,14 +265,12 @@ const Heading = ({
 const Footer = ({
   leading,
   trailing,
-  center,
   currentStep,
   stepCount,
   stepStatus,
 }: {
   leading?: React.ReactNode
   trailing: React.ReactNode
-  center?: boolean
 } & StepProps) => {
   const calcStepType = React.useCallback(
     (step: number) => {
@@ -303,9 +304,9 @@ const Footer = ({
         </StepContainer>
       )}
       {showButtons && (
-        <ButtonsContainer {...{ $center: center }}>
-          {leading || (!center && <div style={{ flexGrow: 1 }} />)}
-          {trailing || (!center && <div style={{ flexGrow: 1 }} />)}
+        <ButtonsContainer>
+          {leading}
+          {trailing}
         </ButtonsContainer>
       )}
     </FooterContainer>

--- a/docs/src/reference/mdx/organisms/Dialog.docs.mdx
+++ b/docs/src/reference/mdx/organisms/Dialog.docs.mdx
@@ -50,16 +50,12 @@ import { Dialog } from '@ensdomains/thorin'
       Open Actionable Dialog
     </Button>
     <Dialog
-      leading={
-        <Button shadowless variant="secondary">
-          Leading
-        </Button>
-      }
+      leading={<Button variant="secondary">Leading</Button>}
       open={getState('dialog-actionable')}
       stepCount={3}
       subtitle="This is an actionable dialog."
       title="Actionable Dialog"
-      trailing={<Button shadowless>Trailing</Button>}
+      trailing={<Button>Trailing</Button>}
       variant="actionable"
       onDismiss={() => toggleState('dialog-actionable')}
     >
@@ -89,16 +85,12 @@ import { Dialog } from '@ensdomains/thorin'
     <Button onClick={() => toggleState('dialog-steps-0')}>Not Started</Button>
     <Dialog
       currentStep={0}
-      leading={
-        <Button shadowless variant="secondary">
-          Leading
-        </Button>
-      }
+      leading={<Button variant="secondary">Leading</Button>}
       open={getState('dialog-steps-0')}
       stepCount={3}
       subtitle="This dialog has 0/3 steps complete."
       title="Start"
-      trailing={<Button shadowless>Trailing</Button>}
+      trailing={<Button>Trailing</Button>}
       variant="actionable"
       onDismiss={() => toggleState('dialog-steps-0')}
     >
@@ -111,16 +103,12 @@ import { Dialog } from '@ensdomains/thorin'
     </Button>
     <Dialog
       currentStep={1}
-      leading={
-        <Button shadowless variant="secondary">
-          Leading
-        </Button>
-      }
+      leading={<Button variant="secondary">Leading</Button>}
       open={getState('dialog-steps-1')}
       stepCount={3}
       subtitle="This dialog has step 1 in progress."
       title="Start"
-      trailing={<Button shadowless>Trailing</Button>}
+      trailing={<Button>Trailing</Button>}
       variant="actionable"
       onDismiss={() => toggleState('dialog-steps-1')}
     >
@@ -133,16 +121,12 @@ import { Dialog } from '@ensdomains/thorin'
     </Button>
     <Dialog
       currentStep={4}
-      leading={
-        <Button shadowless variant="secondary">
-          Leading
-        </Button>
-      }
+      leading={<Button variant="secondary">Leading</Button>}
       open={getState('dialog-steps-2')}
       stepCount={3}
       subtitle="This dialog has all steps."
       title="Start"
-      trailing={<Button shadowless>Trailing</Button>}
+      trailing={<Button>Trailing</Button>}
       variant="actionable"
       onDismiss={() => toggleState('dialog-steps-2')}
     >
@@ -155,17 +139,13 @@ import { Dialog } from '@ensdomains/thorin'
     </Button>
     <Dialog
       currentStep={2}
-      leading={
-        <Button shadowless variant="secondary">
-          Leading
-        </Button>
-      }
+      leading={<Button variant="secondary">Leading</Button>}
       open={getState('dialog-steps-3')}
       stepCount={3}
       stepStatus="notStarted"
       subtitle="This dialog has step 3 not started."
       title="Start"
-      trailing={<Button shadowless>Trailing</Button>}
+      trailing={<Button>Trailing</Button>}
       variant="actionable"
       onDismiss={() => toggleState('dialog-steps-3')}
     >


### PR DESCRIPTION
the flex direction of buttons in a dialog footer were previously calculated based on a provided prop.
now the direction is calculated based on a media query to be more opinionated.
when at 640px or below, the buttons are always stacked vertically.
when above 640px, the buttons are stacked horizontally.