### PR TITLE
Update installation instructions to include peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A design system for ENS built with React and styled-components.
 To install this package using npm:
 
 ```bash
-npm install @ensdomains/thorin styled-components react-transition-state
+npm install @ensdomains/thorin styled-components react-transition-state@1.1.5
 
 ```
 
 To install this package using yarn:
 
 ```bash
-yarn add @ensdomains/thorin styled-components react-transition-state
+yarn add @ensdomains/thorin styled-components react-transition-state@1.1.5
 ```
 
 Checkout the project's [playroom](https://thorin.ens.domains/playroom) to preview the components in a live online environment.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A design system for ENS built with React and styled-components.
 To install this package using npm:
 
 ```bash
-npm install @ensdomains/thorin
+npm install @ensdomains/thorin styled-components react-transition-state
 
 ```
 
 To install this package using yarn:
 
 ```bash
-yarn add @ensdomains/thorin
+yarn add @ensdomains/thorin styled-components react-transition-state
 ```
 
 Checkout the project's [playroom](https://thorin.ens.domains/playroom) to preview the components in a live online environment.

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -14,7 +14,7 @@ import { Header, Link } from '~/components'
 ## Install
 
 ```bash
-yarn add @ensdomains/thorin styled-components react-transition-state
+yarn add @ensdomains/thorin styled-components react-transition-state@1.1.5
 ```
 
 ## Set Up

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -14,7 +14,7 @@ import { Header, Link } from '~/components'
 ## Install
 
 ```bash
-yarn add @ensdomains/thorin
+yarn add @ensdomains/thorin styled-components react-transition-state
 ```
 
 ## Set Up


### PR DESCRIPTION
`@ensdomains/thorin` requires peer dependencies `styled-components` and `react-transition-state` but these are not listed in the initial install instructions. 

added them to the `Install` section of the docs and `README.md`