### PR TITLE
update exports for types

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -7,7 +7,10 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/index.es.js"
+      },
       "require": "./dist/index.cjs.js"
     },
     "./styles": {


### PR DESCRIPTION
Importing `@ensdomains/thorin` returns the following error:

```
Could not find a declaration file for module '@ensdomains/thorin'. 'PROJECT_DIR/node_modules/@ensdomains/thorin/dist/index.es.js' implicitly has an 'any' type.
There are types at 'PROJECT_DIR/node_modules/@ensdomains/thorin/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@ensdomains/thorin' library may need to update its package.json or typings.
```

It seems it's unable to resolve the types defined in the `package.json` file. A possibile solution is the proposed one, where the `types` are set explicitly in the `exports.".".import.types` field:

```json
"import": {
    "types": "./dist/types/index.d.ts",
    "default": "./dist/index.es.js"
}
```

For reference the `tsconfig.json` file used is the default one from Next.js:

```json
{
  "compilerOptions": {
    "target": "es5",
    "lib": ["dom", "dom.iterable", "esnext"],
    "allowJs": true,
    "skipLibCheck": true,
    "strict": true,
    "noEmit": true,
    "esModuleInterop": true,
    "module": "esnext",
    "moduleResolution": "bundler",
    "resolveJsonModule": true,
    "isolatedModules": true,
    "jsx": "preserve",
    "incremental": true,
    "plugins": [
      {
        "name": "next"
      }
    ],
    "paths": {
      "@/*": ["./*"]
    },
    "forceConsistentCasingInFileNames": true
  },
  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
  "exclude": ["node_modules"]
}
```
 