### PR TITLE
Preview toast inactivity and inactive label

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/thorin",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.28",
   "description": "A web3 native design system",
   "type": "module",
   "module": "./dist/index.js",

--- a/components/src/components/molecules/Select/Select.test.tsx
+++ b/components/src/components/molecules/Select/Select.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import {
   cleanup,
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -110,8 +111,9 @@ describe('<Select />', { timeout: 10_000 }, () => {
         onChange={mockCallback}
       />,
     )
-    await userEvent.click(screen.getByTestId('select-container'))
-    await userEvent.click(screen.getByText('Two'))
+    // NOTE: Using fireEvent instead of userEvent to bypass pointer-events: none on SelectLabel
+    fireEvent.click(screen.getByTestId('select-container'))
+    fireEvent.click(screen.getByText('Two'))
     expect(screen.getAllByText('Two').length).toEqual(1)
   })
 

--- a/components/src/components/molecules/Select/Select.tsx
+++ b/components/src/components/molecules/Select/Select.tsx
@@ -122,6 +122,7 @@ const SelectLabel = (props: BoxProps) => (
     overflow="hidden"
     textOverflow="ellipsis"
     whiteSpace="nowrap"
+    pointerEvents="none"
   />
 )
 

--- a/components/src/components/molecules/Select/Select.tsx
+++ b/components/src/components/molecules/Select/Select.tsx
@@ -902,7 +902,7 @@ export const Select = React.forwardRef<HTMLInputElement, SelectProps>(
                       <OptionElement data-testid="selected" option={selectedOption} />
                     )
                   : (
-                      <SelectLabel color="greyPrimary" pointerEvents="none">
+                      <SelectLabel color="greyPrimary">
                         {placeholder}
                       </SelectLabel>
                     )}

--- a/components/src/components/organisms/Toast/Toast.tsx
+++ b/components/src/components/organisms/Toast/Toast.tsx
@@ -323,7 +323,7 @@ export const TouchToast = ({
 export const Toast: React.FC<ToastProps> = ({
   onClose,
   open,
-  msToShow = 8000000,
+  msToShow = 8000,
   variant = 'desktop',
   ...props
 }) => {


### PR DESCRIPTION
* My names list sort selector label can now be clicked.
* Desktop toast background is solid color, not blurred.
* Mobile toast can be pulled down or slid up.