### PR TITLE
fix(FileInput): ignore drag-and-drop when disabled

### DIFF
--- a/components/src/components/atoms/FileInput/FileInput.test.tsx
+++ b/components/src/components/atoms/FileInput/FileInput.test.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react'
 
-import { cleanup, render, screen, waitFor } from '@/test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@/test'
 
 import { FileInput } from './FileInput'
 
 describe('<FileInput />', () => {
+  // jsdom does not implement these, and selecting a file triggers a preview URL.
+  beforeAll(() => {
+    URL.createObjectURL = vi.fn(() => 'blob:mock') as typeof URL.createObjectURL
+    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL
+  })
+
   afterEach(cleanup)
 
   it('renders', () => {
@@ -28,5 +34,43 @@ describe('<FileInput />', () => {
     await waitFor(() => {
       expect(ref.current).toBeInstanceOf(HTMLInputElement)
     })
+  })
+
+  const dropFile = (label: HTMLElement, file: File) =>
+    fireEvent.drop(label, {
+      dataTransfer: {
+        files: [file],
+        items: [{ kind: 'file', getAsFile: () => file }],
+      },
+    })
+
+  it('accepts a dropped file', async () => {
+    const onChange = vi.fn()
+    render(
+      <FileInput onChange={onChange}>
+        {context => (context.name ? <div>{context.name}</div> : <div>Upload file</div>)}
+      </FileInput>,
+    )
+    const label = screen.getByText(/upload/i).closest('label') as HTMLElement
+    dropFile(label, new File(['a'], 'photo.png', { type: 'image/png' }))
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('photo.png')).toBeInTheDocument()
+    })
+  })
+
+  it('ignores a dropped file when disabled', async () => {
+    const onChange = vi.fn()
+    render(
+      <FileInput disabled onChange={onChange}>
+        {context => (context.name ? <div>{context.name}</div> : <div>Upload file</div>)}
+      </FileInput>,
+    )
+    const label = screen.getByText(/upload/i).closest('label') as HTMLElement
+    dropFile(label, new File(['a'], 'photo.png', { type: 'image/png' }))
+    // handleFile (and its onChange) fire synchronously during the drop dispatch,
+    // so a rejected drop leaves onChange uncalled and no filename rendered.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.queryByText('photo.png')).not.toBeInTheDocument()
   })
 })

--- a/components/src/components/atoms/FileInput/FileInput.tsx
+++ b/components/src/components/atoms/FileInput/FileInput.tsx
@@ -125,22 +125,25 @@ export const FileInput = React.forwardRef<HTMLDivElement, FileInputProps>(
 
     const handleDragOver = React.useCallback(
       (event: React.DragEvent<HTMLLabelElement>) => {
+        if (disabled) return
         event.preventDefault()
         setState(x => ({ ...x, droppable: true }))
       },
-      [],
+      [disabled],
     )
 
     const handleDragLeave = React.useCallback(
       (event: React.DragEvent<HTMLLabelElement>) => {
+        if (disabled) return
         event.preventDefault()
         setState(x => ({ ...x, droppable: false }))
       },
-      [],
+      [disabled],
     )
 
     const handleDrop = React.useCallback(
       (event: React.DragEvent<HTMLLabelElement>) => {
+        if (disabled) return
         event.preventDefault()
         setState(x => ({ ...x, droppable: false }))
         let file: File | null
@@ -158,7 +161,7 @@ export const FileInput = React.forwardRef<HTMLDivElement, FileInputProps>(
         if (!validateAccept(file.type, accept)) return
         handleFile(file, event)
       },
-      [handleFile, accept],
+      [handleFile, accept, disabled],
     )
 
     const handleFocus = React.useCallback(


### PR DESCRIPTION
closes #118

## the bug

`FileInput` renders `<input disabled={disabled}>`, which blocks the click-to-upload path, but the label's drag handlers (`handleDragOver`/`handleDragLeave`/`handleDrop`) never checked `disabled`. So a disabled `FileInput` still accepted a dropped file (`handleDrop` -> `handleFile` -> `onChange`).

## the fix

Guard all three drag handlers with `if (disabled) return` (and add `disabled` to each `useCallback` dependency array). `handleDragOver` returns before `preventDefault`, so a disabled target falls back to the browser's native reject-the-drop behavior (and no-drop cursor); `handleDrop` is guarded too as belt-and-suspenders for synthetic/quirky drops that fire without a permitted dragover.

## tests

Added two cases to `FileInput.test.tsx`:
- enabled control: dropping a file calls `onChange` and renders the filename.
- disabled: dropping a file does not call `onChange` and renders no filename (fails on the pre-fix code).

Selecting a file triggers the component's preview-URL effect, so the tests mock `URL.createObjectURL`/`revokeObjectURL`, which jsdom does not implement.

## receipts

- `FileInput.test.tsx`: 4 tests pass.
- Full component suite: 42 files / 148 tests pass, 0 fail.
- `tsc --noEmit` clean; no new lint (the two `FileInput` warnings are pre-existing, on the preview-URL effect).
