### PR TITLE
fix(Input): support type="number" and type="date"

### DIFF
--- a/components/src/components/molecules/Input/Input.test.tsx
+++ b/components/src/components/molecules/Input/Input.test.tsx
@@ -29,6 +29,20 @@ describe('<Input />', () => {
     })
   })
 
+  describe('[type=number]', () => {
+    it('renders a number input', () => {
+      render(<Input label="Amount" type="number" />)
+      expect(screen.getByRole('spinbutton')).toHaveAttribute('type', 'number')
+    })
+  })
+
+  describe('[type=date]', () => {
+    it('renders a date input', () => {
+      render(<Input label="Birthday" type="date" />)
+      expect(screen.getByLabelText(/birthday/i)).toHaveAttribute('type', 'date')
+    })
+  })
+
   it('should pass a ref down', async () => {
     const ref = { current: null } as React.RefObject<HTMLInputElement>
     render(

--- a/components/src/components/molecules/Input/Input.tsx
+++ b/components/src/components/molecules/Input/Input.tsx
@@ -109,6 +109,14 @@ type WithTypeText = {
   maxLength?: NativeInputProps['maxLength']
 }
 
+type WithTypeNumber = {
+  type?: 'number'
+}
+
+type WithTypeDate = {
+  type?: 'date'
+}
+
 type WithTypeDateTimeLocal = {
   type?: 'datetime-local'
 }
@@ -311,7 +319,14 @@ const InnerContainer = ({
   />
 )
 
-export type InputProps = BaseProps & (WithTypeEmail | WithTypeText | WithTypeDateTimeLocal)
+export type InputProps = BaseProps &
+  (
+    | WithTypeEmail
+    | WithTypeText
+    | WithTypeNumber
+    | WithTypeDate
+    | WithTypeDateTimeLocal
+  )
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (


### PR DESCRIPTION
closes #116

## the bug

`<Input type="number" />` failed to type-check. `BaseProps['type']` lists `'number'` (and `'date'`), and the component already forwards the value to the DOM input (`inputType = type === 'email' ? 'text' : type`, then `type={inputType}`), but the `InputProps` union only had `WithTypeEmail | WithTypeText | WithTypeDateTimeLocal`. The intersection restricted `type` to those three, so `number` and `date` were unreachable.

## the fix

Add `WithTypeNumber` and `WithTypeDate` variants to the union. `'date'` is the same one-line defect on the same union (advertised in `BaseProps['type']`, forwarded to the DOM identically), so it is fixed here too rather than left as an obvious sibling gap. This is purely additive: existing `email`/`text`/`datetime-local` callers are unaffected. `min`/`max`/`step` are already allowed via the `NativeInputProps` spread on `BaseProps`, so the new variants stay bare.

## tests

Added a render test per new type asserting the forwarded DOM attribute (`type="number"` renders a `spinbutton` with `type="number"`; `type="date"` renders an input with `type="date"`). These would not compile before the fix, which is itself the type-level proof.

## receipts

- `Input.test.tsx`: 7 tests pass.
- Full component suite: 42 files pass, 0 fail.
- `tsc --noEmit` clean; no new lint.

Unrelated follow-up worth a separate issue: `onWheel` is omitted from the input props and there is no wheel guard, so a focused number input scroll-changes its value. Out of scope here.
